### PR TITLE
Prevent splitting while in zoom

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -139,7 +139,7 @@ function! MyCtrlW()
 
   if zoom#statusline() == 'Z'
     if char is# 'v' || char is# 's' || char is# '' || char is# ''
-      return ""
+      return "" " TODO: '\<C-w>z\<C-w>'.char
     endif
   end
   return "\<C-w>".char

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -1,13 +1,13 @@
 call plug#begin('~/.vim/plugged')
 
 Plug 'chrisbra/matchit'
+Plug 'dhruvasagar/vim-zoom'
 Plug 'junegunn/fzf'
 Plug 'moll/vim-bbye'
 Plug 'ntpeters/vim-better-whitespace'
 Plug 'tpope/vim-eunuch'
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-surround'
-Plug 'troydm/zoomwintab.vim'
 
 " languages
 Plug 'tpope/vim-rails'
@@ -18,7 +18,7 @@ call plug#end()
 
 " STATUS LINE
 set statusline=
-set statusline+=%<\ %f%{ZoomState()}
+set statusline+=%<\ %f%{zoom#statusline()}
 set statusline+=\ %m%r%y%w%=
 set statusline+=\ Line:\ %l\/%L\ [%p%%]
 set statusline+=\ Col:\ %v
@@ -131,28 +131,6 @@ map <Leader>pu :PlugUpdate<cr>
 let g:terraform_align=1
 
 " zoomwintab.vim
-nnoremap <C-w>z :call MyZoomWinTabToggle()<CR>
-nnoremap <C-w><C-z> :call MyZoomWinTabToggle()<CR>
-function! MyZoomWinTabToggle()
-  call zoomwintab#Toggle()
-  if exists('t:zoomwintab')
-    echo 'unmap'
-    nnoremap <C-w>s <nop>
-    nnoremap <C-w>v <nop>
-    nnoremap <C-w><C-s> <nop>
-    nnoremap <C-w><C-v> <nop>
-  else
-    echo 'remap'
-    nnoremap <C-w>s :split<cr>
-    nnoremap <C-w>v :vsplit<cr>
-    nnoremap <C-w><C-s> :split<cr>
-    nnoremap <C-w><C-v> :vsplit<cr>
-  endif
-endfunction
-function! ZoomState()
-  if exists('t:zoomwintab')
-    return 'Z'
-  else
-    return ''
-  endif
-endfunction
+nmap <C-w>z <Plug>(zoom-toggle)
+nmap <C-w><C-z> <Plug>(zoom-toggle)
+let g:zoom#statustext='Z'

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -134,3 +134,14 @@ let g:terraform_align=1
 nmap <C-w>z <Plug>(zoom-toggle)
 nmap <C-w><C-z> <Plug>(zoom-toggle)
 let g:zoom#statustext='Z'
+function! MyCtrlW()
+  let char = nr2char(getchar())
+
+  if zoom#statusline() == 'Z'
+    if char is# 'v' || char is# 's' || char is# '' || char is# ''
+      return ""
+    endif
+  end
+  return "\<C-w>".char
+endfunction
+nnoremap <expr> <C-w> MyCtrlW()

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -139,7 +139,7 @@ function! MyCtrlW()
 
   if get(t:, 'zoomed', 0) == 1
     if char is# 'v' || char is# 's' || char is# '' || char is# ''
-      return "" " TODO: '\<C-w>z\<C-w>'.char
+      return ""
     endif
   end
   return "\<C-w>".char

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -131,8 +131,24 @@ map <Leader>pu :PlugUpdate<cr>
 let g:terraform_align=1
 
 " zoomwintab.vim
-nnoremap <C-w>z :ZoomWinTabToggle<CR>
-nnoremap <C-w><C-z> :ZoomWinTabToggle<CR>
+nnoremap <C-w>z :call MyZoomWinTabToggle()<CR>
+nnoremap <C-w><C-z> :call MyZoomWinTabToggle()<CR>
+function! MyZoomWinTabToggle()
+  call zoomwintab#Toggle()
+  if exists('t:zoomwintab')
+    echo 'unmap'
+    nnoremap <C-w>s <nop>
+    nnoremap <C-w>v <nop>
+    nnoremap <C-w><C-s> <nop>
+    nnoremap <C-w><C-v> <nop>
+  else
+    echo 'remap'
+    nnoremap <C-w>s :split<cr>
+    nnoremap <C-w>v :vsplit<cr>
+    nnoremap <C-w><C-s> :split<cr>
+    nnoremap <C-w><C-v> :vsplit<cr>
+  endif
+endfunction
 function! ZoomState()
   if exists('t:zoomwintab')
     return 'Z'

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -137,7 +137,7 @@ let g:zoom#statustext='Z'
 function! MyCtrlW()
   let char = nr2char(getchar())
 
-  if zoom#statusline() == 'Z'
+  if get(t:, 'zoomed', 0) == 1
     if char is# 'v' || char is# 's' || char is# '' || char is# ''
       return "" " TODO: '\<C-w>z\<C-w>'.char
     endif


### PR DESCRIPTION
Future: How to do

```
"\<C-w>z\<C-w>".char
```
which seems right with it's result
```
calling MyCtrlW()

line 1:   let char = nr2char(getchar())
line 2: 
line 3:   if get(t:, 'zoomed', 0) == 1
line 4:     if char is# 'v' || char is# 's' || char is# '^V' || char is# '^S'
line 5:       return "\<C-w>z\<C-w>".char
MyCtrlW returning '^Wz^Ws' 
```

or other options that don't work?
```
"\<Plug>(zoom-toggle)\<C-w>".char
```
or
```
return "\<esc>\<plug>(zoom-toggle)\<C-w>".char 
```
aka...learn vimscript